### PR TITLE
feat: improve sign out button discoverability on trial popup

### DIFF
--- a/components/TrialPopup.tsx
+++ b/components/TrialPopup.tsx
@@ -11,6 +11,7 @@ import {
   Headphones,
   Loader2,
   CheckCircle2,
+  LogOut,
 } from "lucide-react";
 
 const CHECKOUT_LINK =
@@ -181,8 +182,9 @@ export function TrialPopup({ userEmail }: TrialPopupProps) {
 
         <button
           onClick={() => void signOut()}
-          className="mt-3 w-full text-center text-xs text-muted transition-colors hover:text-foreground"
+          className="mt-3 flex w-full items-center justify-center gap-2 rounded-lg border border-border py-2 text-sm text-muted transition-colors hover:bg-muted-bg hover:text-foreground"
         >
+          <LogOut className="h-4 w-4" />
           Sign out
         </button>
       </div>

--- a/tests/trial-popup-signout.spec.ts
+++ b/tests/trial-popup-signout.spec.ts
@@ -108,4 +108,71 @@ test.describe("TrialPopup Sign Out", () => {
 
     await context.close();
   });
+
+  test("TC5 — CTA hierarchy: Start free trial is visually dominant above Sign out", async ({
+    browser,
+  }) => {
+    const { context, page } = await signUpFreshUser(browser, "tc5");
+
+    await expect(
+      page.getByRole("heading", { name: "Start your free trial" })
+    ).toBeVisible({ timeout: 10_000 });
+
+    const ctaButton = page.getByRole("button", { name: "Start free trial" });
+    const signOutButton = page.getByRole("button", { name: "Sign out" });
+
+    await expect(ctaButton).toBeVisible();
+    await expect(signOutButton).toBeVisible();
+
+    const ctaBox = await ctaButton.boundingBox();
+    const signOutBox = await signOutButton.boundingBox();
+
+    expect(ctaBox).not.toBeNull();
+    expect(signOutBox).not.toBeNull();
+
+    expect(ctaBox!.y).toBeLessThan(signOutBox!.y);
+
+    expect(ctaBox!.width).toBeGreaterThanOrEqual(signOutBox!.width * 0.9);
+
+    await context.close();
+  });
+
+  test("TC6 — Responsive: TrialPopup renders correctly at 375px mobile viewport", async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({
+      storageState: { cookies: [], origins: [] },
+      viewport: { width: 375, height: 812 },
+    });
+    const page = await context.newPage();
+
+    await page.goto("/auth");
+    await page.getByRole("button", { name: "Sign Up" }).click();
+
+    const email = `signout_tc6_${Date.now()}@gmail.com`;
+    await page.getByRole("textbox", { name: "Email" }).fill(email);
+    await page.getByRole("textbox", { name: "Password" }).fill("TestPass123!");
+    await page.getByRole("button", { name: "Create Account" }).click();
+
+    await page.waitForURL("/dashboard", { timeout: 15_000 });
+
+    await expect(
+      page.getByRole("heading", { name: "Start your free trial" })
+    ).toBeVisible({ timeout: 10_000 });
+
+    const ctaButton = page.getByRole("button", { name: "Start free trial" });
+    const signOutButton = page.getByRole("button", { name: "Sign out" });
+
+    await expect(ctaButton).toBeVisible();
+    await expect(signOutButton).toBeVisible();
+
+    const signOutBox = await signOutButton.boundingBox();
+    expect(signOutBox).not.toBeNull();
+    expect(signOutBox!.x).toBeGreaterThanOrEqual(0);
+    expect(signOutBox!.x + signOutBox!.width).toBeLessThanOrEqual(375);
+
+    await expect(page.getByText("$19")).toBeVisible();
+
+    await context.close();
+  });
 });


### PR DESCRIPTION
## Summary

- Promotes the sign out control on `TrialPopup` from a near-invisible `text-xs text-muted` text link to a clearly visible secondary button with a border, `LogOut` icon, and `text-sm` sizing
- Maintains CTA hierarchy: "Start free trial" (accent) remains the dominant action; "Sign out" is secondary but easily discoverable
- No functional changes — the `signOut()` call and auth flow are untouched

Closes #6

## Changes

**`components/TrialPopup.tsx`**
- Added `LogOut` icon import from `lucide-react`
- Updated sign out button classes: `text-xs` → `text-sm`, added `flex items-center justify-center gap-2 rounded-lg border border-border py-2`, added `hover:bg-muted-bg`
- Added `<LogOut />` icon inside the button

## Test plan

- [x] All 4 existing tests in `tests/trial-popup-signout.spec.ts` pass (5/5 including setup)
- [x] `tests/subscription-gates.spec.ts` passes (2/2)
- [x] Visual QA at desktop viewport — sign out button is immediately visible with border and icon
- [x] Visual QA at 375px mobile viewport — popup renders correctly, no layout issues
- [x] CTA hierarchy confirmed: "Start free trial" is visually dominant, "Sign out" is secondary