### PR TITLE
feat(issue-8): Dashboard empty state for zero-document users

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -8,7 +8,7 @@ import { DocumentCard } from "@/components/dashboard/DocumentCard";
 import { NewDocumentButton } from "@/components/dashboard/NewDocumentButton";
 import { AccountDropdown } from "@/components/AccountDropdown";
 import { TrialPopup } from "@/components/TrialPopup";
-import { PenLine, Loader2 } from "lucide-react";
+import { PenLine, Loader2, FileText } from "lucide-react";
 
 function RedirectToAuth() {
   const router = useRouter();
@@ -60,6 +60,17 @@ function DashboardContent() {
         {documents === undefined ? (
           <div className="flex items-center justify-center py-20">
             <Loader2 className="h-6 w-6 animate-spin text-muted" />
+          </div>
+        ) : documents.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-20 text-center">
+            <FileText className="mb-3 h-10 w-10 text-border" />
+            <p className="mb-1 text-sm font-medium text-muted">
+              No documents yet
+            </p>
+            <p className="mb-6 text-xs text-muted">
+              Create your first document to get started.
+            </p>
+            <NewDocumentButton />
           </div>
         ) : (
           <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">

--- a/tests/dashboard-empty-state.spec.ts
+++ b/tests/dashboard-empty-state.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect, Page } from "@playwright/test";
+
+const CONVEX_URL = "https://little-tapir-937.convex.cloud";
+
+async function getConvexToken(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key?.startsWith("__convexAuthJWT")) return localStorage.getItem(key)!;
+    }
+    throw new Error("No Convex auth token found");
+  });
+}
+
+async function deleteAllDocuments(page: Page) {
+  const token = await getConvexToken(page);
+
+  await page.evaluate(
+    async ({ url, token }) => {
+      const headers = {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      };
+
+      const listRes = await fetch(`${url}/api/query`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          path: "documents:list",
+          args: {},
+          format: "json",
+        }),
+      });
+      if (!listRes.ok) throw new Error(`Failed to list documents: ${listRes.status}`);
+
+      const list = await listRes.json();
+      const docs: { _id: string }[] = list.value ?? [];
+
+      for (const doc of docs) {
+        const delRes = await fetch(`${url}/api/mutation`, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            path: "documents:remove",
+            args: { id: doc._id },
+            format: "json",
+          }),
+        });
+        if (!delRes.ok) throw new Error(`Failed to delete ${doc._id}: ${delRes.status}`);
+      }
+    },
+    { url: CONVEX_URL, token }
+  );
+}
+
+test.describe("Dashboard Empty State", () => {
+  test.describe.configure({ mode: "serial" });
+
+  let page: Page;
+
+  test.beforeAll(async ({ browser }) => {
+    const context = await browser.newContext({
+      storageState: "test-artifacts/.auth/user.json",
+    });
+    page = await context.newPage();
+  });
+
+  test.afterAll(async () => {
+    await page.context().close();
+  });
+
+  test("shows empty state when user has no documents", async () => {
+    test.setTimeout(120_000);
+    await page.goto("/dashboard");
+    await expect(
+      page.getByRole("heading", { name: "Your Documents", level: 1 })
+    ).toBeVisible({ timeout: 10_000 });
+
+    await deleteAllDocuments(page);
+
+    await expect(page.getByText("No documents yet")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(
+      page.getByText("Create your first document to get started.")
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "New Document" })
+    ).toBeVisible();
+  });
+
+  test("empty state New Document button creates a document and navigates to editor", async () => {
+    await expect(page.getByText("No documents yet")).toBeVisible({
+      timeout: 5_000,
+    });
+    await page.getByRole("button", { name: "New Document" }).click();
+    await page.waitForURL(/\/document\//, { timeout: 10_000 });
+    await expect(page).toHaveURL(/\/document\/.+/);
+  });
+
+  test("dashboard grid returns after creating a document from empty state", async () => {
+    await page.goto("/dashboard");
+    await expect(
+      page.getByRole("heading", { name: "Your Documents", level: 1 })
+    ).toBeVisible({ timeout: 10_000 });
+
+    await expect(page.getByText("No documents yet")).not.toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "New Document" })
+    ).toBeVisible();
+    await expect(page.getByText("Untitled").first()).toBeVisible();
+  });
+});


### PR DESCRIPTION
# AI PR Summary

Adds an empty state to the dashboard when a user has zero documents, showing a FileText icon, "No documents yet" headline, subtitle, and the existing NewDocumentButton as the primary CTA.

- When `documents.length === 0`, renders a centered empty state block instead of the grid
- When `documents.length > 0`, renders the existing grid as-is (unchanged)
- Visual pattern matches the existing empty state in `KnowledgePanel`
- Includes Playwright tests covering empty state display, New Document button navigation, and grid restoration

Closes #8